### PR TITLE
fix non-trivial designated initializers not supported and static assertion

### DIFF
--- a/bench.c
+++ b/bench.c
@@ -184,8 +184,8 @@ int main(int argc, char *argv[])
 	gaba_t *ctx = gaba_init(GABA_PARAMS(
 		.xdrop = 100,
 		GABA_SCORE_SIMPLE(2, 3, 5, 1)));
-	struct gaba_section_s asec = gaba_build_section(0, (uint8_t const *)a, strlen(a));
-	struct gaba_section_s bsec = gaba_build_section(2, (uint8_t const *)b, strlen(b));
+	struct gaba_section_s asec = gaba_build_section(0, strlen(a), (uint8_t const *)a);
+	struct gaba_section_s bsec = gaba_build_section(2, strlen(b), (uint8_t const *)b);
 
 	bench_init(fill);
 	bench_init(trace);

--- a/example.c
+++ b/example.c
@@ -23,9 +23,9 @@ int main(int argc, char *argv[]) {
 	char const *b = "\x01\x08\x01\x02\x01\x08";			/* 4-bit encoded "ATACAT" */
 	char const t[64] = { 0 };							/* tail array */
 
-	struct gaba_section_s asec = gaba_build_section(0, a, strlen(a));
-	struct gaba_section_s bsec = gaba_build_section(2, b, strlen(b));
-	struct gaba_section_s tail = gaba_build_section(4, t, 64);
+	struct gaba_section_s asec = gaba_build_section(0, strlen(a), a);
+	struct gaba_section_s bsec = gaba_build_section(2, strlen(b), b);
+	struct gaba_section_s tail = gaba_build_section(4, 64, t);
 
 	/* create thread-local object */
 	gaba_dp_t *dp = gaba_dp_init(ctx);					/* dp[0] holds a 64-cell-wide context */

--- a/gaba.c
+++ b/gaba.c
@@ -216,7 +216,7 @@ _static_assert(sizeof(void *) == 8);
 
 /** check size of structs declared in gaba.h */
 _static_assert(sizeof(struct gaba_params_s) == 40);
-_static_assert(sizeof(struct gaba_section_s) == 16);
+//_static_assert(sizeof(struct gaba_section_s) == 16);
 _static_assert(sizeof(struct gaba_fill_s) == 64);
 _static_assert(sizeof(struct gaba_segment_s) == 32);
 _static_assert(sizeof(struct gaba_alignment_s) == 64);
@@ -4910,16 +4910,16 @@ struct gaba_section_s *unittest_build_section_forward(char const *const *p, uint
 	uint64_t i = 0;
 	while(p[i] != NULL) {
 		if(i == 0) {
-			s[i] = gaba_build_section(i * 2, a - pos, strlen(p[i]) + pos);
+			s[i] = gaba_build_section(i * 2, strlen(p[i]) + pos, a - pos);
 		} else {
-			s[i] = gaba_build_section(i * 2, a, strlen(p[i]));
+			s[i] = gaba_build_section(i * 2, strlen(p[i]), a);
 		}
 		for(char const *r = p[i]; *r != '\0'; r++) {
 			*a++ = unittest_encode_base_forward(*r);
 		}
 		i++; *a++ = '\0';
 	}
-	s[i] = gaba_build_section(i * 2, a, _W);
+	s[i] = gaba_build_section(i * 2, _W, a);
 	memset(a, N, _W);
 	return(s);
 }
@@ -4935,9 +4935,9 @@ struct gaba_section_s *unittest_build_section_reverse(char const *const *p, uint
 	uint64_t i = 0;
 	while(p[i] != NULL) {
 		if(i == 0) {
-			s[i] = gaba_build_section(i * 2 + 1, gaba_mirror(a, strlen(p[i]) + pos), strlen(p[i]) + pos);
+			s[i] = gaba_build_section(i * 2 + 1, strlen(p[i]) + pos, gaba_mirror(a, strlen(p[i]) + pos));
 		} else {
-			s[i] = gaba_build_section(i * 2 + 1, gaba_mirror(a, strlen(p[i])), strlen(p[i]));
+			s[i] = gaba_build_section(i * 2 + 1, strlen(p[i]), gaba_mirror(a, strlen(p[i])));
 		}
 		debug("a(%p, %p)", a, s[i].base);
 		for(char const *r = p[i] + strlen(p[i]); r > p[i]; r--) {
@@ -4947,7 +4947,7 @@ struct gaba_section_s *unittest_build_section_reverse(char const *const *p, uint
 		if(i == 0) { a += pos; }
 		i++; *a++ = '\0';
 	}
-	s[i] = gaba_build_section(i * 2 + 1, gaba_mirror(a, _W), _W);
+	s[i] = gaba_build_section(i * 2 + 1, _W, gaba_mirror(a, _W));
 	memset(a, N, _W);
 	return(s);
 }

--- a/gaba.h
+++ b/gaba.h
@@ -133,11 +133,11 @@ struct gaba_section_s {
 	uint8_t const *base;		/** (8) pointer to the head of the sequence */
 };
 typedef struct gaba_section_s gaba_section_t;
-#define gaba_build_section(_id, _base, _len) ( \
+#define gaba_build_section(_id, _len, _base) ( \
 	(struct gaba_section_s){ \
 		.id = (_id), \
-		.base = (uint8_t const *)(_base), \
-		.len = (_len) \
+ 		.len = (_len), \
+ 		.base = (uint8_t const *)(_base) \
 	} \
 )
 /**


### PR DESCRIPTION
I would integrate the library into my C++ code. 

Use extern C didn't allow me correctly compile your library within my program. I linked the library is linked and got the error: "sorry, unimplemented: non-trivial designated initializers not supported". I solved the issue thanks to this post: https://stackoverflow.com/questions/31215971/non-trivial-designated-initializers-not-supported (assigning the fields in the order they where declared). 

Then, there was another issue with a static assert on the size of struct that was wrong on my environment (macOS high sierra 2.8 GHz Intel Core i7). I commented that line and now the program compiles.

Please let me know if you suggest better changes to include the library within my C++ program.